### PR TITLE
ci(pr): add a finalizer to monitor for success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,24 @@ jobs:
           name: vuln-scan-results
           path: vulns.json
           if-no-files-found: error
+  finalizer:
+    # This gives us something to set as required in the repo settings. Some projects use dynamic fan-outs using matrix strategies and the fromJSON function, so
+    # you can't hard-code what _should_ run vs not. Having a finalizer simplifies that so you can just check that the finalizer succeeded, and if so, your
+    # requirements have been met
+    # Example: https://x.com/JonZeolla/status/1877344137713766516
+    name: Finalize the pipeline
+    runs-on: ubuntu-24.04
+    # Keep this aligned with the below steps
+    needs: [lint, test]
+    if: always()  # Ensure it runs even if "needs" fail
+    steps:
+      # Keep this aligned with the above needs
+      - name: Check for failed jobs
+        run: |
+          if [[ "${{ needs.lint.result }}" == "failure" ||
+                "${{ needs.test.result }}" == "failure" ]]; then
+            echo "One or more required jobs failed. Marking finalizer as failed."
+            exit 1
+          fi
+      - name: Finalize
+        run: echo "Pipeline complete!"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,14 +100,14 @@ jobs:
     runs-on: ubuntu-24.04
     # Keep this aligned with the below steps
     needs: [lint, test]
-    if: always()  # Ensure it runs even if "needs" fail
+    if: always()  # Ensure it runs even if "needs" fails or is cancelled
     steps:
       # Keep this aligned with the above needs
       - name: Check for failed jobs
         run: |
-          if [[ "${{ needs.lint.result }}" == "failure" ||
-                "${{ needs.test.result }}" == "failure" ]]; then
-            echo "One or more required jobs failed. Marking finalizer as failed."
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ||
+                "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs failed or was cancelled. Marking finalizer as failed."
             exit 1
           fi
       - name: Finalize

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 ---
 name: "CI"
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   push:
     branches:
@@ -98,12 +102,11 @@ jobs:
     # Example: https://x.com/JonZeolla/status/1877344137713766516
     name: Finalize the pipeline
     runs-on: ubuntu-24.04
-    # Keep this aligned with the below steps
+    # Keep this aligned with the above jobs
     needs: [lint, test]
     if: always()  # Ensure it runs even if "needs" fails or is cancelled
     steps:
-      # Keep this aligned with the above needs
-      - name: Check for failed jobs
+      - name: Check for failed or cancelled jobs
         run: |
           if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ||
                 "${{ contains(needs.*.result, 'cancelled') }}" == "true" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: "CI"
 
 permissions:
   contents: read
-  actions: write
 
 on:
   push:
@@ -39,6 +38,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4

--- a/{{cookiecutter.project_name|replace(" ", "")}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_name|replace(" ", "")}}/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 ---
 name: CI
 
+permissions:
+  contents: read
+  actions: write
+
 on:
   pull_request:
     branches: [main]
@@ -123,17 +127,16 @@ jobs:
     # Example: https://x.com/JonZeolla/status/1877344137713766516
     name: Finalize the pipeline
     runs-on: ubuntu-24.04
-    # Keep this aligned with the below steps
+    # Keep this aligned with the above jobs
     needs: [lint, test, build]
-    if: always()  # Ensure it runs even if "needs" fail
+    if: always()  # Ensure it runs even if "needs" fails or is cancelled
     steps:
-      # Keep this aligned with the above needs
-      - name: Check for failed jobs
+      - name: Check for failed or cancelled jobs
         run: |
           # Use contains() to check for any failure or cancellation
-          if [[ "{% raw %}${{ contains(needs.*.result, 'failure') }}{% endraw %}" == "true" || 
+          if [[ "{% raw %}${{ contains(needs.*.result, 'failure') }}{% endraw %}" == "true" ||
                 "{% raw %}${{ contains(needs.*.result, 'cancelled') }}{% endraw %}" == "true" ]]; then
-            echo "One or more required jobs failed. Marking finalizer as failed."
+            echo "One or more required jobs failed or was cancelled. Marking finalizer as failed."
             exit 1
           fi
       - name: Finalize

--- a/{{cookiecutter.project_name|replace(" ", "")}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_name|replace(" ", "")}}/.github/workflows/ci.yml
@@ -3,7 +3,6 @@ name: CI
 
 permissions:
   contents: read
-  actions: write
 
 on:
   pull_request:
@@ -20,6 +19,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4

--- a/{{cookiecutter.project_name|replace(" ", "")}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_name|replace(" ", "")}}/.github/workflows/ci.yml
@@ -116,3 +116,25 @@ jobs:
           name: vulns-${{ "{{ env.SANITIZED_PLATFORM }}" }}
           path: vulns.*.json
           if-no-files-found: error
+  finalizer:
+    # This gives us something to set as required in the repo settings. Some projects use dynamic fan-outs using matrix strategies and the fromJSON function, so
+    # you can't hard-code what _should_ run vs not. Having a finalizer simplifies that so you can just check that the finalizer succeeded, and if so, your
+    # requirements have been met
+    # Example: https://x.com/JonZeolla/status/1877344137713766516
+    name: Finalize the pipeline
+    runs-on: ubuntu-24.04
+    # Keep this aligned with the below steps
+    needs: [lint, test, build]
+    if: always()  # Ensure it runs even if "needs" fail
+    steps:
+      # Keep this aligned with the above needs
+      - name: Check for failed jobs
+        run: |
+          if [[ "{% raw %}${{ needs.lint.result }}{% endraw %}" == "failure" ||
+                "{% raw %}${{ needs.test.result }}{% endraw %}" == "failure" ||
+                "{% raw %}${{ needs.build.result }}{% endraw %}" == "failure" ]]; then
+            echo "One or more required jobs failed. Marking finalizer as failed."
+            exit 1
+          fi
+      - name: Finalize
+        run: echo "Pipeline complete!"

--- a/{{cookiecutter.project_name|replace(" ", "")}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_name|replace(" ", "")}}/.github/workflows/ci.yml
@@ -130,9 +130,9 @@ jobs:
       # Keep this aligned with the above needs
       - name: Check for failed jobs
         run: |
-          if [[ "{% raw %}${{ needs.lint.result }}{% endraw %}" == "failure" ||
-                "{% raw %}${{ needs.test.result }}{% endraw %}" == "failure" ||
-                "{% raw %}${{ needs.build.result }}{% endraw %}" == "failure" ]]; then
+          # Use contains() to check for any failure or cancellation
+          if [[ "{% raw %}${{ contains(needs.*.result, 'failure') }}{% endraw %}" == "true" || 
+                "{% raw %}${{ contains(needs.*.result, 'cancelled') }}{% endraw %}" == "true" ]]; then
             echo "One or more required jobs failed. Marking finalizer as failed."
             exit 1
           fi


### PR DESCRIPTION
# Contributor Comments

This adds a "finalizer" to simplify the configuration of policy requirements. For example, after this merges the following can be replaced with just a check on the `finalizer` after this merges. It seems trivial, but if you follow [this](https://x.com/JonZeolla/status/1877344137713766516) and [this](https://x.com/JonZeolla/status/1915169752080675325) link you can see how it is very powerful.

<img width="753" alt="Screenshot 2025-07-02 at 4 37 42 PM" src="https://github.com/user-attachments/assets/7af038b5-5570-4bf0-a4c9-473893dc1790" />

## Pull Request Checklist

Thank you for submitting a contribution!

Please address the following items:

- [X] If you are adding a dependency, please explain how it was chosen.
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [X] Validate that documentation is accurate and aligned to any project updates or additions.