### PR TITLE
chore(task): improve built-in tasks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -86,8 +86,8 @@ tasks:
   update:
     desc: Update the project dev and runtime dependencies
     cmds:
-      # This currently assumes uv was installed via uv; we will want to make it more flexible in the future
-      - brew upgrade uv
+      # This currently assumes uv was installed via uv (locally); we will want to make it more flexible in the future
+      - '{{if ne .GITHUB_ACTIONS "true"}}brew upgrade uv{{end}}'
       - pre-commit autoupdate --freeze --jobs 4
       # Copy the newly updated config into the project template, excluding the exclude line
       - cat .pre-commit-config.yaml | grep -v ^exclude > '{{`{{cookiecutter.project_name|replace(" ", "")}}`}}/.pre-commit-config.yaml'

--- a/{{cookiecutter.project_name|replace(" ", "")}}/Taskfile.yml
+++ b/{{cookiecutter.project_name|replace(" ", "")}}/Taskfile.yml
@@ -167,11 +167,14 @@ tasks:
   update:
     desc: Update the project dev and runtime dependencies
     cmds:
+      # This currently assumes uv was installed via uv (locally); we will want to make it more flexible in the future
+      - '{{if ne .GITHUB_ACTIONS "true"}}brew upgrade uv{{end}}'
+      - pre-commit autoupdate --freeze --jobs 4
       - uv lock --upgrade
       # This can take a while but it's required for the following step to update BuildKit in the docker driver
-      - docker buildx rm multiplatform || true
-      # Because we just destroyed the "multiplatform" builder instance, this will configure a new one. The next time
-      # the host runs a `docker buildx build` it will rebuild the builder instance, updating its BuildKit
+      - '{{if eq .CLI_ARGS "all"}}docker buildx rm multiplatform || true{{end}}'
+      # If we just destroyed the "multiplatform" builder instance, this will configure a new one. The next time the host runs a `docker buildx build` it will
+      # rebuild the builder instance, updating its BuildKit. There's no harm in running this even if we didn't do the `docker buildx rm` previously
       - task: init-docker-multiplatform
 
   clean:


### PR DESCRIPTION
# Contributor Comments

This improves a number of built-in tasks:
- `task update` in the root project now only updates `uv` via `brew` on a local system (i.e. not CI, where it's installed with `setup-uv`
- `task update` in the template project is now better aligned with the root project, so it updates `pre-commit` pins, `uv`, and only deletes the `multiplatform` builder if you `task update -- all` because it's a bit aggressive and not needed often.

## Pull Request Checklist

Thank you for submitting a contribution!

Please address the following items:

- [X] If you are adding a dependency, please explain how it was chosen.
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [X] Validate that documentation is accurate and aligned to any project updates or additions.