### PR TITLE
chore(mcp): ignore .mcp.json files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.mcp.json
 .task/*
 .lycheecache
 sbom.*.*.json

--- a/{{cookiecutter.project_name|replace(" ", "")}}/.gitignore
+++ b/{{cookiecutter.project_name|replace(" ", "")}}/.gitignore
@@ -1,3 +1,4 @@
+.mcp.json
 .task/*
 .lycheecache
 sbom.*.json


### PR DESCRIPTION
# Contributor Comments

Add `.mcp.json` files to the `.gitignore` so you can configure MCP servers without checking them in.

## Pull Request Checklist

Thank you for submitting a contribution!

Please address the following items:

- [X] If you are adding a dependency, please explain how it was chosen.
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [X] Validate that documentation is accurate and aligned to any project updates or additions.