### PR TITLE
chore(dockerfile): remove unnecessary ubuntu docker base

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -7,7 +7,6 @@
   "github_org": "zenable-io",
   "project_owner_github_username": "jonzeolla",
   "python_version": ["3.13", "3.12", "3.11"],
-  "docker_base": ["ubuntu:22.04", "ubuntu:20.04", "ubuntu:23.04"],
   "dockerhub": ["no", "yes"],
   "public": ["no", "yes"],
   "license": ["NONE", "MIT", "BSD-3-Clause"]


### PR DESCRIPTION
# Contributor Comments

This removes the `docker_base` question, since we don't use `Ubuntu` as our parent image, we use the `python` images directly.

This will also have the side effect of speeding up CI/tests because we will have 2 fewer combinations to test generation.

## Pull Request Checklist

Thank you for submitting a contribution!

Please address the following items:

- [X] If you are adding a dependency, please explain how it was chosen.
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [X] Validate that documentation is accurate and aligned to any project updates or additions.