### PR TITLE
fix(dependabot): specify directory for Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,7 +49,7 @@ updates:
 
   # Enable version updates for Docker
   - package-ecosystem: "docker"
-    directory: "/"
+    directory: '/{{cookiecutter.project_name|replace(" ", "")}}/'
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
# Contributor Comments

This fixes the Dependabot `Dockerfile` scan logic in the root project. Previously it was having an issue finding the `Dockerfile`:

<img width="909" alt="Screenshot 2025-07-08 at 10 41 00 AM" src="https://github.com/user-attachments/assets/09b5a6c0-1c46-460d-8846-a8315b820a69" />

[Here](https://github.com/Zenable-io/ai-native-python/actions/runs/16112747504) is an example run that failed.

## Pull Request Checklist

Thank you for submitting a contribution!

Please address the following items:

- [X] If you are adding a dependency, please explain how it was chosen.
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [X] Validate that documentation is accurate and aligned to any project updates or additions.