### PR TITLE
ci(release): reduce permissions, avoid persisting credentials

### DIFF
--- a/{{cookiecutter.project_name|replace(" ", "")}}/.github/workflows/release.yml
+++ b/{{cookiecutter.project_name|replace(" ", "")}}/.github/workflows/release.yml
@@ -17,7 +17,6 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
-      pull-requests: write
     outputs:
       tag: ${{ "{{ steps.release.outputs.tag }}" }}
     steps:
@@ -25,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ "{{ secrets.GITHUB_TOKEN }}" }}
+          persist-credentials: 'false'
 
       - name: Bootstrap repository
         uses: ./.github/actions/bootstrap


### PR DESCRIPTION
# Contributor Comments

This reduces the permissions of the `GITHUB_TOKEN` when running a release on a generated project (it no longer asks for PR: write permissions), and it also doesn't persist `git` creds, which is the default for `actions/checkout@v4`

I manually tested this in a project I generated and saw that it was still able to make a relase.

<img width="978" alt="Screenshot 2025-07-08 at 11 39 54 AM" src="https://github.com/user-attachments/assets/14099cdd-1d4b-4877-96fd-9c858efddb55" />

## Pull Request Checklist

Thank you for submitting a contribution!

Please address the following items:

- [X] If you are adding a dependency, please explain how it was chosen.
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [X] Validate that documentation is accurate and aligned to any project updates or additions.