### PR TITLE
ci(security): avoid persisting credentials on checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: 'false'
       - name: Bootstrap repository
         uses: ./.github/actions/bootstrap
         with:
@@ -47,6 +49,7 @@ jobs:
         if: github.event_name != 'pull_request'
         with:
           fetch-depth: 0
+          persist-credentials: 'false'
       - name: Checkout the repository
         uses: actions/checkout@v4
         # Necessary for hooks to succeed during tests for PRs
@@ -54,6 +57,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          persist-credentials: 'false'
       - name: Bootstrap repository
         uses: ./.github/actions/bootstrap
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: 'false'
 
       - name: Bootstrap repository
         uses: ./.github/actions/bootstrap

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: 'false'
       - name: Bootstrap repository
         uses: ./.github/actions/bootstrap
         with:

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: 'false'
       - name: Bootstrap repository
         uses: ./.github/actions/bootstrap
         with:

--- a/{{cookiecutter.project_name|replace(" ", "")}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_name|replace(" ", "")}}/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: 'false'
       - name: Bootstrap repository
         uses: ./.github/actions/bootstrap
         with:
@@ -49,6 +51,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: 'false'
       - name: Bootstrap repository
         uses: ./.github/actions/bootstrap
         with:
@@ -69,6 +73,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: 'false'
       - name: Bootstrap repository
         uses: ./.github/actions/bootstrap
         with:

--- a/{{cookiecutter.project_name|replace(" ", "")}}/.github/workflows/commit.yml
+++ b/{{cookiecutter.project_name|replace(" ", "")}}/.github/workflows/commit.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: 'false'
       - name: Bootstrap repository
         uses: ./.github/actions/bootstrap
         with:
@@ -41,6 +43,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: 'false'
       - name: Bootstrap repository
         uses: ./.github/actions/bootstrap
         with:
@@ -116,6 +119,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: "${{ "{{ needs.bump-version.outputs.tag }}" }}"
+          persist-credentials: 'false'
       - name: Bootstrap repository
         uses: ./.github/actions/bootstrap
         with:

--- a/{{cookiecutter.project_name|replace(" ", "")}}/.github/workflows/security.yml
+++ b/{{cookiecutter.project_name|replace(" ", "")}}/.github/workflows/security.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: 'false'
       - name: Bootstrap repository
         uses: ./.github/actions/bootstrap
         with:

--- a/{{cookiecutter.project_name|replace(" ", "")}}/.github/workflows/update.yml
+++ b/{{cookiecutter.project_name|replace(" ", "")}}/.github/workflows/update.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: 'false'
       - name: Bootstrap repository
         uses: ./.github/actions/bootstrap
         with:


### PR DESCRIPTION
# Contributor Comments

This ensures we don't persist creds on checkout; according to my testing it is not necessary and it's generally unsafe (even though it is the `actions/checkout` default). When we implement `zizmor` in the future (on our roadmap), this will be enforced via CI but for now we're adding it as best effort.

## Pull Request Checklist

Thank you for submitting a contribution!

Please address the following items:

- [X] If you are adding a dependency, please explain how it was chosen.
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [X] Validate that documentation is accurate and aligned to any project updates or additions.