### PR TITLE
fix(lint): add cookiecutter inputs to generated project dictionary.txt

### DIFF
--- a/{{cookiecutter.project_name|replace(" ", "")}}/.github/etc/dictionary.txt
+++ b/{{cookiecutter.project_name|replace(" ", "")}}/.github/etc/dictionary.txt
@@ -1,4 +1,10 @@
-{%- set fragments = cookiecutter.project_slug.split('_') -%}
+{%- set fragments = cookiecutter.project_name.split('_')
+                  + cookiecutter.project_slug.split('_')
+                  + cookiecutter.project_short_description.split(' ')
+                  + cookiecutter.company_name.split('_')
+                  + cookiecutter.company_domain.split('_')
+                  + cookiecutter.github_org.split('_')
+                  + cookiecutter.project_owner_github_username.split('_') -%}
 {%- for item in fragments -%}
 {{ item }}
 {% endfor %}


### PR DESCRIPTION
# Contributor Comments

This adds additional cookiecutter question/answers to the dictionary to ensure they are not flagged as linter failures after generation. For instance, if you provided `Jon Zeolla` before as the company name, it would fail because it didn't know what `Zeolla` is.

I generated a project and tested, and now the dictionary has the correct details:

<img width="116" alt="Screenshot 2025-07-09 at 5 20 12 PM" src="https://github.com/user-attachments/assets/f39de703-28ab-4d82-93f8-4a28b7d7a261" />

## Pull Request Checklist

Thank you for submitting a contribution!

Please address the following items:

- [X] If you are adding a dependency, please explain how it was chosen.
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [X] Validate that documentation is accurate and aligned to any project updates or additions.