### PR TITLE
feat(docker): use project name for docker image

### DIFF
--- a/{{cookiecutter.project_name|replace(" ", "")}}/Taskfile.yml
+++ b/{{cookiecutter.project_name|replace(" ", "")}}/Taskfile.yml
@@ -9,7 +9,7 @@ set:
   - pipefail
 
 vars:
-  IMAGE_NAME: '{{ cookiecutter.github_org }}/{{ cookiecutter.project_name }}'
+  IMAGE_NAME: '{{ cookiecutter.github_org }}/{{ cookiecutter.project_name | lower }}'
   PROJECT_SLUG: {{ cookiecutter.project_slug }}
   PYTHON_VERSION: {{ cookiecutter.python_version }}
   SUPPORTED_PLATFORMS: 'linux/amd64,linux/arm64'

--- a/{{cookiecutter.project_name|replace(" ", "")}}/Taskfile.yml
+++ b/{{cookiecutter.project_name|replace(" ", "")}}/Taskfile.yml
@@ -9,7 +9,7 @@ set:
   - pipefail
 
 vars:
-  IMAGE_NAME: '{{ cookiecutter.github_org }}/{{ cookiecutter.project_slug }}'
+  IMAGE_NAME: '{{ cookiecutter.github_org }}/{{ cookiecutter.project_name }}'
   PROJECT_SLUG: {{ cookiecutter.project_slug }}
   PYTHON_VERSION: {{ cookiecutter.python_version }}
   SUPPORTED_PLATFORMS: 'linux/amd64,linux/arm64'


### PR DESCRIPTION
# Contributor Comments

This uses the project name (instead of the slug) for the docker image, which is more intuitive.

## Pull Request Checklist

Thank you for submitting a contribution!

Please address the following items:

- [X] If you are adding a dependency, please explain how it was chosen.
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [X] Validate that documentation is accurate and aligned to any project updates or additions.