### PR TITLE
ci(codeql): ensure correct permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 env:
   python_version: "3.13"

--- a/{{cookiecutter.project_name|replace(" ", "")}}/.github/workflows/security.yml
+++ b/{{cookiecutter.project_name|replace(" ", "")}}/.github/workflows/security.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 env:
   python_version: "{{ cookiecutter.python_version }}"


### PR DESCRIPTION
# Contributor Comments

This sets the required `security-events: write` permissions for CodeQL to update the security events of a given repo.

Without this, you will see:
<img width="1041" alt="Screenshot 2025-07-09 at 7 35 26 PM" src="https://github.com/user-attachments/assets/ec7180fa-8d77-4c48-9ba6-b022179c0db7" />

## Pull Request Checklist

Thank you for submitting a contribution!

Please address the following items:

- [X] If you are adding a dependency, please explain how it was chosen.
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [X] Validate that documentation is accurate and aligned to any project updates or additions.