### PR TITLE
fix(lint): ensure dictionary.txt contains inputs

### DIFF
--- a/{{cookiecutter.project_name|replace(" ", "")}}/.github/etc/dictionary.txt
+++ b/{{cookiecutter.project_name|replace(" ", "")}}/.github/etc/dictionary.txt
@@ -1,7 +1,9 @@
 {%- set fragments = cookiecutter.project_name.split('_')
+                  + cookiecutter.project_name.split('-')
                   + cookiecutter.project_slug.split('_')
                   + cookiecutter.project_short_description.split(' ')
                   + cookiecutter.company_name.split('_')
+                  + cookiecutter.company_name.split(' ')
                   + cookiecutter.company_domain.split('_')
                   + cookiecutter.github_org.split('_')
                   + cookiecutter.project_owner_github_username.split('_') -%}


### PR DESCRIPTION
# Contributor Comments

This ensures that the generated `dictionary.txt` has all of the various inputs, even if they have spaces they should be separate entries (like "Jon Zeolla")

## Pull Request Checklist

Thank you for submitting a contribution!

Please address the following items:

- [X] If you are adding a dependency, please explain how it was chosen.
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [X] Validate that documentation is accurate and aligned to any project updates or additions.