### PR TITLE
docs(grant): document optional setup step

### DIFF
--- a/{{cookiecutter.project_name|replace(" ", "")}}/README.md
+++ b/{{cookiecutter.project_name|replace(" ", "")}}/README.md
@@ -29,6 +29,10 @@ PLATFORM=all task build
 
 You can also specify a single platform of either `linux/arm64` or `linux/amd64`
 
+## Optional setup
+
+If you'd like to be able to run `task license-check` locally, you will need to install `grant` and ensure it's in your `PATH`.
+
 ## Troubleshooting
 
 If you're troubleshooting the results of any of the tasks, you can add `-v` to enable debug `task` logging, for instance:


### PR DESCRIPTION
# Contributor Comments

This tells users of the generated project that they will need `grant` locally in order to run `task license-check`

This goes away after https://github.com/Zenable-io/ai-native-python/issues/37

## Pull Request Checklist

Thank you for submitting a contribution!

Please address the following items:

- [X] If you are adding a dependency, please explain how it was chosen.
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [X] Validate that documentation is accurate and aligned to any project updates or additions.