### PR TITLE
docs(readme): fix docker run example to use project name

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,7 +1,7 @@
 {
-  "project_name": "TODO",
+  "project_name": "replace-me",
   "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
-  "project_short_description": "TODO",
+  "project_short_description": "A brief description of the project",
   "company_name": "Zenable Inc",
   "company_domain": "zenable.io",
   "github_org": "zenable-io",

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -273,7 +273,8 @@ def test_default_project(cookies):
                 env=env,
             )
 
-        default_image = "zenable-io/todo:latest"
+        # It's important that this has -s in the name to test the docker hub image name sanitization
+        default_image = "zenable-io/replace-me:latest"
 
         # Ensure that --help exits 0
         subprocess.run(

--- a/tests/test_cookiecutter.py
+++ b/tests/test_cookiecutter.py
@@ -24,8 +24,8 @@ LOCAL_PLATFORM = f"{plat.system().lower()}/{plat.machine()}"
 def get_config() -> dict:
     """Generate all the config keys"""
     config_file = Path("./cookiecutter.json")
-    with open(config_file) as file_object:
-        config = json.load(file_object)
+    with config_file.open(encoding="utf-8") as f:
+        config = json.load(f)
     return config
 
 
@@ -227,6 +227,19 @@ def test_default_project(cookies):
     if repo.is_dirty(untracked_files=True):
         pytest.fail("Something went wrong with the project's post-generation hook")
 
+    # Extract project_name and project_slug from cookiecutter.json
+    config_file = Path("./cookiecutter.json")
+    with config_file.open(encoding="utf-8") as f:
+        generated_config = json.load(f)
+        github_org = generated_config.get("github_org")
+        project_name = generated_config.get("project_name")
+        project_name_lower = project_name.lower()
+
+        # Keep this logic aligned with the template's README.md
+        # It's important that this has -s in the name to test the docker hub image name sanitization
+        default_image_name = f"{github_org}/{project_name_lower}"
+        default_image_name_and_tag = f"{default_image_name}:latest"
+
     try:
         env = os.environ.copy()
         env.pop("VIRTUAL_ENV", None)  # Clean VIRTUAL_ENV to avoid conflicts
@@ -273,12 +286,9 @@ def test_default_project(cookies):
                 env=env,
             )
 
-        # It's important that this has -s in the name to test the docker hub image name sanitization
-        default_image = "zenable-io/replace-me:latest"
-
         # Ensure that --help exits 0
         subprocess.run(
-            ["docker", "run", "--rm", default_image, "--help"],
+            ["docker", "run", "--rm", default_image_name_and_tag, "--help"],
             capture_output=True,
             check=True,
             cwd=project,
@@ -289,7 +299,7 @@ def test_default_project(cookies):
             "docker",
             "run",
             "--rm",
-            default_image,
+            default_image_name_and_tag,
             "--debug",
             "--verbose",
         ]

--- a/{{cookiecutter.project_name|replace(" ", "")}}/README.md
+++ b/{{cookiecutter.project_name|replace(" ", "")}}/README.md
@@ -18,7 +18,7 @@ task init
 task build
 
 # Run the image
-docker run {{ cookiecutter.github_org }}/{{ cookiecutter.project_slug }}:0.0.0 --help
+docker run {{ cookiecutter.github_org }}/{{ cookiecutter.project_name }}:0.0.0 --help
 ```
 
 If you'd like to build all of the supported docker images, you can set the `PLATFORM` env var to `all` like this:

--- a/{{cookiecutter.project_name|replace(" ", "")}}/README.md
+++ b/{{cookiecutter.project_name|replace(" ", "")}}/README.md
@@ -18,7 +18,7 @@ task init
 task build
 
 # Run the image
-docker run {{ cookiecutter.github_org }}/{{ cookiecutter.project_name }}:0.0.0 --help
+docker run {{ cookiecutter.github_org }}/{{ cookiecutter.project_name | lower }}:0.0.0 --help
 ```
 
 If you'd like to build all of the supported docker images, you can set the `PLATFORM` env var to `all` like this:

--- a/{{cookiecutter.project_name|replace(" ", "")}}/tests/test_integration.py
+++ b/{{cookiecutter.project_name|replace(" ", "")}}/tests/test_integration.py
@@ -102,7 +102,7 @@ def test_docker_image():
     Test that the Docker image builds and runs correctly.
     """
     project_root = Path(__file__).parent.parent
-    image_name = "{{ cookiecutter.github_org }}/{{ cookiecutter.project_slug }}"
+    image_name = "{{ cookiecutter.github_org }}/{{ cookiecutter.project_name | lower }}"
 
     pyproject_file = project_root / "pyproject.toml"
 


### PR DESCRIPTION
# Contributor Comments

There was a small docs mistake, showing the wrong image name in the `docker run` example

## Pull Request Checklist

Thank you for submitting a contribution!

Please address the following items:

- [X] If you are adding a dependency, please explain how it was chosen.
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [X] Validate that documentation is accurate and aligned to any project updates or additions.