### PR TITLE
chore(pre-commit): remove pre-commit hook, moving to zenable-io/ai-guardrails

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,0 @@
----
-- id: zenable-check
-  name: Run a Zenable check on all changed files
-  language: system
-  entry: zenable check
-  pass_filenames: true


### PR DESCRIPTION
# Contributor Comments

Our pre-commit hook has moved to https://github.com/Zenable-io/ai-guardrails

Depends on https://github.com/Zenable-io/ai-guardrails/pull/1

## Pull Request Checklist

Thank you for submitting a contribution!

Please address the following items:

- [X] If you are adding a dependency, please explain how it was chosen.
- [X] If manual testing is needed in order to validate the changes, provide a testing plan and the expected results.
- [X] Validate that documentation is accurate and aligned to any project updates or additions.